### PR TITLE
forever increasing sequences to simplify state

### DIFF
--- a/src/rasengan.rs
+++ b/src/rasengan.rs
@@ -19,13 +19,13 @@ impl<T: Copy, const N: usize> Rasengan<T, N> {
         (idx + 1) % self.buf.len()
     }
 
-    fn is_full(&self) -> bool {
+    fn will_overwrite_unread_data(&self) -> bool {
         self.write_ptr + 1 == self.read_ptr + self.buf.len()
     }
 
     // Overwrites when buffer is full
     pub fn write(&mut self, data: T) {
-        if self.is_full() {
+        if self.will_overwrite_unread_data() {
             self.read_ptr += 1;
         }
 


### PR DESCRIPTION
# Simplify struct fields

To determine whether pointers are crossing each other I was maintaining extra state in the field `has_no_unread_data`.
However using always increasing pointers with a clever pointer increment policy simplifies the state management.

- `read_ptr` is incremented after reading
- `write_ptr` is incremented before writing
- both pointers always increase until `usize` bounds
- mod is only done while getting array elements

This approach is a little less readable (due to different increment policy) and has an upper limit on how many times you can write to the buffer (`usize` limit) after which it'll cause overflow.

--- 
## Write with wrap-around
![circular_buffer_with_overflow](https://github.com/tauseefk/rasengan/assets/11029896/33d0cb17-74bd-4b1f-8683-981f894fef10)

---
## Fork in the road
Depending on the sequence of operations there are two alternatives:

### Read with wrap-around
In this case the reader resumes, so no unread values were overwritten.

![circular_buffer_with_no_overwrite](https://github.com/tauseefk/rasengan/assets/11029896/b643e0ff-e764-4462-ad3d-ff122f3a01e3)

### Write with overwrites
In this case the reader is still busy and the writer overwrites unread values. The read pointer is then moved to the least recent values in the buffer.

![circular_buffer_with_overwrite](https://github.com/tauseefk/rasengan/assets/11029896/f21b353d-cbe6-471e-b5d3-98e8f329edba)


